### PR TITLE
Remove '原文字幕' from DEFAULT_SELECTED_SECTIONS in section.ts

### DIFF
--- a/src/types/section.ts
+++ b/src/types/section.ts
@@ -56,8 +56,7 @@ export const ALL_SECTION_TYPES: SectionType[] = [
 // 默认选中的小节 - 移除工具相关的小节
 export const DEFAULT_SELECTED_SECTIONS: SectionType[] = [
   '总结',
-  '分段详述',
-  '原文字幕'
+  '分段详述'
 ];
 
 // 工具按钮对应的小节类型


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `原文字幕` from `DEFAULT_SELECTED_SECTIONS`, leaving only `总结` and `分段详述` selected by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eb8e74a6d5a722f857e5bfd72121569605de48e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->