### PR TITLE
feat: YouTube 无字幕时走腾讯 ASR，失败则整篇失败

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,18 +4,20 @@ FROM python:3.11-slim
 # 设置工作目录
 WORKDIR /app
 
-# 安装系统依赖和 Node.js
+# Node 22 is required by yt-dlp EJS for YouTube audio downloads.
+# ffmpeg is required to fix the m4a container after DASH audio download.
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
     ca-certificates \
     gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    ffmpeg \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# 验证 Node.js 安装
-RUN node --version && npm --version
+# 验证 Node.js / ffmpeg 安装
+RUN node --version && npm --version && ffmpeg -version | head -n 1
 
 # 复制 requirements.txt
 COPY requirements.txt .

--- a/backend/app/routers/workflow.py
+++ b/backend/app/routers/workflow.py
@@ -439,6 +439,16 @@ async def process_article_task(request: FetchRequest):
             
             # 保存字幕内容
             await SupabaseService.update_content(request.id, content)
+            if getattr(request, "platform", None) == "youtube" and "转录内容:" not in content:
+                error_msg = "Unable to get subtitle content"
+                await RequestLogger.error(
+                    request.id,
+                    Steps.CONTENT_FETCH,
+                    error_msg,
+                    Exception(error_msg)
+                )
+                await SupabaseService.update_status(request.id, "failed", error_msg)
+                return
         
         # 等待确保数据已保存
         await asyncio.sleep(1)

--- a/backend/app/services/content_fetcher/service.py
+++ b/backend/app/services/content_fetcher/service.py
@@ -32,6 +32,8 @@ class ContentFetcherService:
                 if fetcher.can_handle(url):
                     if isinstance(fetcher, FileFetcher) and self.request and self.request.content:
                         return await fetcher.fetch(url, self.request)
+                    if isinstance(fetcher, YouTubeFetcher):
+                        return await fetcher.fetch(url, self.request)
                     return await fetcher.fetch(url)
             return None
         except Exception as e:

--- a/backend/app/services/content_fetcher/youtube.py
+++ b/backend/app/services/content_fetcher/youtube.py
@@ -19,6 +19,8 @@ from app.models.request import FetchRequest
 from app.models.author import AuthorInfo
 from app.models.article import ArticleCreate
 from app.services.transcript.fallback_provider import TranscriptFallbackProvider
+from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
+from app.services.transcript.text_utils import build_youtube_content
 import unicodedata
 import os
 import re as _re
@@ -186,20 +188,29 @@ class YouTubeFetcher(ContentFetcher):
                 except Exception as _:
                     # 兜底错误不影响主流程
                     logger.exception("[YT Fallback] Unexpected error during fallback pipeline")
-            
-            # 组合内容
-            content_parts = [
-                f"标题: {video_info.title}",
-                f"作者: {video_info.author}",
-                f"描述: {video_info.description}",
-            ]
-            
-            if transcript:
-                content_parts.append(f"转录内容: {transcript}")
-            
-            content = "\n\n".join(content_parts)
+
+            # 字幕与小宇宙都失败时，下载音频走腾讯 ASR（与私密音频同一套公网 URL）
+            if not transcript:
+                try:
+                    user_id = (request.user_id if request else None) or "youtube-asr"
+                    logger.info("[YT Audio ASR] Captions empty. Download audio and transcribe...")
+                    provider = YouTubeAudioAsrProvider()
+                    transcript = await provider.transcribe(url, user_id)
+                except Exception:
+                    logger.exception("[YT Audio ASR] Unexpected error during audio ASR pipeline")
+                    transcript = None
+
+            content = build_youtube_content(
+                video_info.title,
+                video_info.author,
+                video_info.description,
+                transcript,
+            )
+            if not content:
+                logger.error("YouTube transcript unavailable after captions, XiaoYuZhou fallback, and audio ASR")
+                return None
+
             logger.info(f"成功获取YouTube内容，长度: {len(content)}")
-            
             return content
             
         except Exception as e:

--- a/backend/app/services/transcript/tencent_asr.py
+++ b/backend/app/services/transcript/tencent_asr.py
@@ -11,6 +11,8 @@ from tencentcloud.common.profile.client_profile import ClientProfile
 from tencentcloud.common.profile.http_profile import HttpProfile
 from tencentcloud.asr.v20190614 import asr_client, models
 
+from app.services.transcript.text_utils import strip_inner_timestamps
+
 
 class TencentASRClient:
     def __init__(self):
@@ -88,13 +90,15 @@ class TencentASRClient:
         if isinstance(detail, list) and detail:
             for seg in detail:
                 bg = seg.get("SliceStartTime", 0) / 1000.0
-                text = seg.get("FinalSentence") or seg.get("Text") or ""
+                text = strip_inner_timestamps(
+                    seg.get("FinalSentence") or seg.get("Text") or ""
+                )
                 ts = self._sec_to_hhmmss(bg)
                 if text:
-                    lines.append(f"[{ts}] {text.strip()}")
+                    lines.append(f"[{ts}] {text}")
         else:
             # fallback: use Result plain text without timestamps
-            plain = data.get("Result", "").strip()
+            plain = strip_inner_timestamps(data.get("Result", ""))
             if plain:
                 lines.append(f"[00:00:00] {plain}")
         return "\n".join(lines)

--- a/backend/app/services/transcript/text_utils.py
+++ b/backend/app/services/transcript/text_utils.py
@@ -1,0 +1,32 @@
+"""Pure transcript text helpers — no cloud SDK imports."""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+INNER_TIMESTAMP_RE = re.compile(r"\[\d+:\d+(?:\.\d+)?,\d+:\d+(?:\.\d+)?\]\s*")
+
+
+def strip_inner_timestamps(text: Optional[str]) -> str:
+    if not text:
+        return ""
+    return INNER_TIMESTAMP_RE.sub("", text).strip()
+
+
+def build_youtube_content(
+    title: str,
+    author,
+    description: Optional[str],
+    transcript: Optional[str],
+) -> Optional[str]:
+    """Assemble LLM input. Returns None when there is no real transcript."""
+    if not transcript or not str(transcript).strip():
+        return None
+    return "\n\n".join(
+        [
+            f"标题: {title}",
+            f"作者: {author}",
+            f"描述: {description or ''}",
+            f"转录内容: {str(transcript).strip()}",
+        ]
+    )

--- a/backend/app/services/transcript/youtube_audio.py
+++ b/backend/app/services/transcript/youtube_audio.py
@@ -22,11 +22,67 @@ class YouTubeAudioAsrProvider:
     """yt-dlp m4a download → Supabase public URL → Tencent ASR."""
 
     AUDIO_FORMAT = "140/bestaudio[ext=m4a]/bestaudio"
+    PLAYER_CLIENT = "youtube:player_client=tv_embedded"
 
     def __init__(self) -> None:
         self.yt_dlp = shutil.which("yt-dlp") or "yt-dlp"
         self.node = shutil.which("node")
         self.ffmpeg = shutil.which("ffmpeg")
+
+    def _webshare_proxy_urls(self) -> list[str]:
+        """Return HTTP proxies that can fetch googlevideo (not Web Unlocker)."""
+        token = os.getenv("WEBSHARE_API_TOKEN")
+        if not token:
+            try:
+                from app.config import settings
+
+                token = getattr(settings, "WEBSHARE_API_TOKEN", None)
+            except Exception:
+                token = None
+        if not token:
+            return []
+        try:
+            import requests
+
+            resp = requests.get(
+                "https://proxy.webshare.io/api/v2/proxy/list/",
+                headers={"Authorization": f"Token {token}"},
+                params={"mode": "direct", "page": 1, "page_size": 10},
+                timeout=20,
+            )
+            resp.raise_for_status()
+            results = resp.json().get("results") or []
+        except Exception as e:
+            logger.warning(f"[YT Audio ASR] webshare list failed: {type(e).__name__}")
+            return []
+
+        ranked = sorted(results, key=lambda item: 0 if item.get("country_code") == "US" else 1)
+        urls: list[str] = []
+        for item in ranked:
+            user = item.get("username")
+            password = item.get("password")
+            address = item.get("proxy_address")
+            port = item.get("port")
+            if all([user, password, address, port]):
+                urls.append(f"http://{user}:{password}@{address}:{port}")
+        return urls
+
+    def _base_cmd(self, out_tmpl: str) -> list[str]:
+        return [
+            self.yt_dlp,
+            "--js-runtimes",
+            f"node:{self.node}",
+            "--impersonate",
+            "chrome",
+            "--extractor-args",
+            self.PLAYER_CLIENT,
+            "-f",
+            self.AUDIO_FORMAT,
+            "-o",
+            out_tmpl,
+            "--no-playlist",
+            "--no-warnings",
+        ]
 
     def _download_audio(self, video_url: str, dest_dir: str) -> str:
         if not self.node:
@@ -35,55 +91,50 @@ class YouTubeAudioAsrProvider:
             logger.warning("[YT Audio ASR] ffmpeg not found; m4a container fixup may fail")
 
         out_tmpl = str(Path(dest_dir) / "audio.%(ext)s")
-        cmd = [
-            self.yt_dlp,
-            "--js-runtimes",
-            f"node:{self.node}",
-            "-f",
-            self.AUDIO_FORMAT,
-            "-o",
-            out_tmpl,
-            "--no-playlist",
-            "--no-warnings",
-        ]
-        proxy_url = None
-        use_proxy_env = os.getenv("USE_PROXY")
-        if use_proxy_env is not None:
-            if use_proxy_env.lower() == "true":
-                proxy_url = os.getenv("PROXY_URL")
-        else:
-            try:
-                from app.config import settings
+        proxies = self._webshare_proxy_urls()
+        if not proxies:
+            logger.warning("[YT Audio ASR] no Webshare proxies; trying direct download")
+            proxies = [None]
 
-                if getattr(settings, "USE_PROXY", False) and getattr(settings, "PROXY_URL", None):
-                    proxy_url = settings.PROXY_URL
-            except Exception:
-                proxy_url = None
-        if proxy_url:
-            # Bright Data web unlocker MITMs TLS; same verify=False pattern as caption fetch.
-            cmd.extend(["--proxy", proxy_url, "--no-check-certificates"])
-            logger.info("[YT Audio ASR] yt-dlp proxy enabled")
-        cmd.append(video_url)
-        logger.info(f"[YT Audio ASR] download start url={video_url}")
-        completed = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=int(os.getenv("YOUTUBE_AUDIO_DOWNLOAD_TIMEOUT", "180")),
-            check=False,
-        )
-        if completed.returncode != 0:
-            err = (completed.stderr or completed.stdout or "").strip()[-800:]
-            raise RuntimeError(f"yt-dlp failed: {err}")
+        timeout = int(os.getenv("YOUTUBE_AUDIO_DOWNLOAD_TIMEOUT", "300"))
+        last_err = "yt-dlp failed"
+        for proxy_url in proxies[:5]:
+            cmd = self._base_cmd(out_tmpl)
+            if proxy_url:
+                cmd.extend(["--proxy", proxy_url])
+                logger.info("[YT Audio ASR] yt-dlp webshare proxy enabled")
+            cmd.append(video_url)
+            logger.info(f"[YT Audio ASR] download start url={video_url}")
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            err = (completed.stderr or completed.stdout or "").strip()
+            if proxy_url:
+                err = err.replace(proxy_url, "[proxy]")
+            if completed.returncode == 0:
+                files = [
+                    path
+                    for path in Path(dest_dir).glob("audio.*")
+                    if path.is_file() and path.stat().st_size > 0
+                ]
+                if files:
+                    audio_path = str(files[0])
+                    logger.info(
+                        f"[YT Audio ASR] download ok path={audio_path} size={os.path.getsize(audio_path)}"
+                    )
+                    return audio_path
+                last_err = "yt-dlp finished but produced no audio file"
+            else:
+                last_err = err[-800:] or last_err
+                logger.warning("[YT Audio ASR] yt-dlp attempt failed, trying next proxy")
+            for leftover in Path(dest_dir).glob("audio.*"):
+                leftover.unlink(missing_ok=True)
 
-        files = list(Path(dest_dir).glob("audio.*"))
-        if not files:
-            raise RuntimeError("yt-dlp finished but produced no audio file")
-        audio_path = str(files[0])
-        logger.info(
-            f"[YT Audio ASR] download ok path={audio_path} size={os.path.getsize(audio_path)}"
-        )
-        return audio_path
+        raise RuntimeError(f"yt-dlp failed: {last_err}")
 
     async def transcribe(self, video_url: str, user_id: str) -> Optional[str]:
         dest_dir = tempfile.mkdtemp(prefix="yt-asr-")

--- a/backend/app/services/transcript/youtube_audio.py
+++ b/backend/app/services/transcript/youtube_audio.py
@@ -1,0 +1,111 @@
+"""Download YouTube audio and transcribe it with the production Tencent ASR path.
+
+YouTube CDN URLs cannot be passed to Tencent (they require signed headers).
+Production therefore downloads m4a locally, uploads to Supabase Storage
+(`private-uploads`), and sends that public URL to CreateRecTask — the same
+URL pattern used by private audio uploads.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from app.utils.logger import logger
+
+
+class YouTubeAudioAsrProvider:
+    """yt-dlp m4a download → Supabase public URL → Tencent ASR."""
+
+    AUDIO_FORMAT = "140/bestaudio[ext=m4a]/bestaudio"
+
+    def __init__(self) -> None:
+        self.yt_dlp = shutil.which("yt-dlp") or "yt-dlp"
+        self.node = shutil.which("node")
+        self.ffmpeg = shutil.which("ffmpeg")
+
+    def _download_audio(self, video_url: str, dest_dir: str) -> str:
+        if not self.node:
+            raise RuntimeError("Node.js >= 22 is required for yt-dlp YouTube downloads")
+        if not self.ffmpeg:
+            logger.warning("[YT Audio ASR] ffmpeg not found; m4a container fixup may fail")
+
+        out_tmpl = str(Path(dest_dir) / "audio.%(ext)s")
+        cmd = [
+            self.yt_dlp,
+            "--js-runtimes",
+            f"node:{self.node}",
+            "-f",
+            self.AUDIO_FORMAT,
+            "-o",
+            out_tmpl,
+            "--no-playlist",
+            "--no-warnings",
+            video_url,
+        ]
+        logger.info(f"[YT Audio ASR] download start url={video_url}")
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=int(os.getenv("YOUTUBE_AUDIO_DOWNLOAD_TIMEOUT", "180")),
+            check=False,
+        )
+        if completed.returncode != 0:
+            err = (completed.stderr or completed.stdout or "").strip()[-800:]
+            raise RuntimeError(f"yt-dlp failed: {err}")
+
+        files = list(Path(dest_dir).glob("audio.*"))
+        if not files:
+            raise RuntimeError("yt-dlp finished but produced no audio file")
+        audio_path = str(files[0])
+        logger.info(
+            f"[YT Audio ASR] download ok path={audio_path} size={os.path.getsize(audio_path)}"
+        )
+        return audio_path
+
+    async def transcribe(self, video_url: str, user_id: str) -> Optional[str]:
+        dest_dir = tempfile.mkdtemp(prefix="yt-asr-")
+        try:
+            audio_path = await asyncio.to_thread(self._download_audio, video_url, dest_dir)
+            with open(audio_path, "rb") as fh:
+                audio_bytes = fh.read()
+            filename = Path(audio_path).name
+            from app.services.private_content_service import PrivateContentService
+
+            public_url = await PrivateContentService.upload_audio_to_storage(
+                audio_bytes, filename, user_id or "youtube-asr"
+            )
+            if not public_url:
+                logger.error("[YT Audio ASR] supabase upload returned empty URL")
+                return None
+            logger.info(f"[YT Audio ASR] public_url={public_url}")
+
+            def _run_asr(url: str) -> str:
+                from app.services.transcript.tencent_asr import TencentASRClient
+
+                asr = TencentASRClient()
+                task_id = asr.create_task(url)
+                logger.info(f"[YT Audio ASR] tencent task_id={task_id}")
+                result = asr.poll_result(task_id)
+                status = (result.get("Data") or {}).get("StatusStr")
+                logger.info(f"[YT Audio ASR] tencent status={status}")
+                if status != "success":
+                    raise RuntimeError(f"Tencent ASR status={status}")
+                return asr.to_bracketed_transcript(result)
+
+            transcript = await asyncio.to_thread(_run_asr, public_url)
+            if not transcript or not transcript.strip():
+                logger.warning("[YT Audio ASR] empty transcript")
+                return None
+            logger.info(f"[YT Audio ASR] transcript length={len(transcript)}")
+            return transcript
+        except Exception as e:
+            logger.exception(f"[YT Audio ASR] failed: {e}")
+            return None
+        finally:
+            shutil.rmtree(dest_dir, ignore_errors=True)

--- a/backend/app/services/transcript/youtube_audio.py
+++ b/backend/app/services/transcript/youtube_audio.py
@@ -45,8 +45,25 @@ class YouTubeAudioAsrProvider:
             out_tmpl,
             "--no-playlist",
             "--no-warnings",
-            video_url,
         ]
+        proxy_url = None
+        use_proxy_env = os.getenv("USE_PROXY")
+        if use_proxy_env is not None:
+            if use_proxy_env.lower() == "true":
+                proxy_url = os.getenv("PROXY_URL")
+        else:
+            try:
+                from app.config import settings
+
+                if getattr(settings, "USE_PROXY", False) and getattr(settings, "PROXY_URL", None):
+                    proxy_url = settings.PROXY_URL
+            except Exception:
+                proxy_url = None
+        if proxy_url:
+            # Bright Data web unlocker MITMs TLS; same verify=False pattern as caption fetch.
+            cmd.extend(["--proxy", proxy_url, "--no-check-certificates"])
+            logger.info("[YT Audio ASR] yt-dlp proxy enabled")
+        cmd.append(video_url)
         logger.info(f"[YT Audio ASR] download start url={video_url}")
         completed = subprocess.run(
             cmd,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ python-multipart==0.0.19
 pydantic==2.11.6
 pydantic-settings==2.9.1
 supabase==2.16.0
-# yt-dlp==2025.6.9  # 已替换为SerpAPI
+yt-dlp[default]==2026.7.4
 # bgutil-ytdlp-pot-provider==1.1.0  # 已替换为SerpAPI
 asyncio==3.4.3
 typing-extensions==4.12.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ python-multipart==0.0.19
 pydantic==2.11.6
 pydantic-settings==2.9.1
 supabase==2.16.0
-yt-dlp[default]==2026.7.4
+yt-dlp[default,curl-cffi]==2026.7.4
 # bgutil-ytdlp-pot-provider==1.1.0  # 已替换为SerpAPI
 asyncio==3.4.3
 typing-extensions==4.12.2

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# backend tests package

--- a/backend/tests/test_youtube_no_caption.py
+++ b/backend/tests/test_youtube_no_caption.py
@@ -79,6 +79,32 @@ class YoutubeAudioDownloadCommandTest(unittest.TestCase):
             self.assertIn("--js-runtimes", cmd)
             self.assertIn("node:/usr/bin/node", cmd)
             self.assertIn("140/bestaudio[ext=m4a]/bestaudio", cmd)
+            self.assertNotIn("--proxy", cmd)
+
+    def test_download_uses_proxy_when_configured(self):
+        from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
+
+        provider = YouTubeAudioAsrProvider()
+        provider.yt_dlp = "/usr/bin/yt-dlp"
+        provider.node = "/usr/bin/node"
+        provider.ffmpeg = "/usr/bin/ffmpeg"
+
+        with patch.dict(
+            os.environ,
+            {"USE_PROXY": "true", "PROXY_URL": "http://proxy.example:8080"},
+            clear=False,
+        ):
+            with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
+                run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+                with patch("app.services.transcript.youtube_audio.Path.glob", return_value=[]):
+                    with self.assertRaises(RuntimeError):
+                        provider._download_audio(
+                            "https://www.youtube.com/watch?v=toRqAY3xp4A", "/tmp/x"
+                        )
+            cmd = run.call_args[0][0]
+            self.assertIn("--proxy", cmd)
+            self.assertIn("http://proxy.example:8080", cmd)
+            self.assertIn("--no-check-certificates", cmd)
 
 
 class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_youtube_no_caption.py
+++ b/backend/tests/test_youtube_no_caption.py
@@ -1,0 +1,113 @@
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Settings is constructed at import time; tests do not use real secrets.
+_TEST_ENV = {
+    "log_level": "INFO",
+    "SUPABASE_URL": "https://example.supabase.co",
+    "SUPABASE_SERVICE_ROLE_KEY": "test-service-role",
+    "WEBSHARE_API_TOKEN": "x",
+    "COZE_API_TOKEN": "x",
+    "COZE_WORKFLOW_ID_ZH": "x",
+    "COZE_WORKFLOW_ID_EN": "x",
+    "COZE_POLISH_WORKFLOW_ID_ZH": "x",
+    "COZE_POLISH_WORKFLOW_ID_EN": "x",
+    "COZE_DETAILED_WORKFLOW_ID_ZH": "x",
+    "COZE_DETAILED_WORKFLOW_ID_EN": "x",
+    "COZE_WEB_SUMMARY_ID_ZH": "x",
+    "COZE_WEB_SUMMARY_ID_EN": "x",
+    "COZE_FILE_SUMMARY_ID_ZH": "x",
+    "COZE_FILE_SUMMARY_ID_EN": "x",
+    "ASSEMBLYAI_API_KEY": "x",
+    "SERPAPI_KEY": "x",
+    "DEEPSEEK_API_KEY": "x",
+    "OPENROUTER_API_KEY": "x",
+    "DAJIALA_KEY": "x",
+    "DAJIALA_VERIFYCODE": "x",
+    "AWS_ACCESS_KEY_ID": "x",
+    "AWS_SECRET_ACCESS_KEY": "x",
+    "USE_PROXY": "false",
+}
+os.environ.update(_TEST_ENV)
+
+from app.services.transcript.text_utils import strip_inner_timestamps, build_youtube_content
+
+
+class StripInnerTimestampsTest(unittest.TestCase):
+    def test_strips_tencent_slice_prefix(self):
+        raw = "[0:0.000,1:0.300]  大家好，我是布鲁斯"
+        self.assertEqual(strip_inner_timestamps(raw), "大家好，我是布鲁斯")
+
+    def test_keeps_plain_sentence(self):
+        self.assertEqual(strip_inner_timestamps("深蹲时骨盆后倾"), "深蹲时骨盆后倾")
+
+    def test_empty(self):
+        self.assertEqual(strip_inner_timestamps(""), "")
+        self.assertEqual(strip_inner_timestamps(None), "")  # type: ignore[arg-type]
+
+
+class BuildYoutubeContentTest(unittest.TestCase):
+    def test_returns_none_without_transcript(self):
+        self.assertIsNone(build_youtube_content("title", {"name": "a"}, "desc", None))
+        self.assertIsNone(build_youtube_content("title", {"name": "a"}, "desc", "   "))
+
+    def test_includes_transcript_marker(self):
+        content = build_youtube_content("T", {"name": "A"}, "D", "[00:00:00] hello")
+        self.assertIsNotNone(content)
+        self.assertIn("标题: T", content)
+        self.assertIn("描述: D", content)
+        self.assertIn("转录内容: [00:00:00] hello", content)
+
+
+class YoutubeAudioDownloadCommandTest(unittest.TestCase):
+    def test_download_invokes_yt_dlp_with_node_runtime(self):
+        from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
+
+        provider = YouTubeAudioAsrProvider()
+        provider.yt_dlp = "/usr/bin/yt-dlp"
+        provider.node = "/usr/bin/node"
+        provider.ffmpeg = "/usr/bin/ffmpeg"
+
+        with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            with patch("app.services.transcript.youtube_audio.Path.glob", return_value=[]):
+                with self.assertRaises(RuntimeError):
+                    provider._download_audio("https://www.youtube.com/watch?v=toRqAY3xp4A", "/tmp/x")
+            cmd = run.call_args[0][0]
+            self.assertEqual(cmd[0], "/usr/bin/yt-dlp")
+            self.assertIn("--js-runtimes", cmd)
+            self.assertIn("node:/usr/bin/node", cmd)
+            self.assertIn("140/bestaudio[ext=m4a]/bestaudio", cmd)
+
+
+class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_returns_none_when_all_transcripts_fail(self):
+        try:
+            from app.services.content_fetcher.youtube import YouTubeFetcher
+            from app.services.content_fetcher.base import VideoInfo
+        except ImportError as e:
+            self.skipTest(f"youtube fetcher deps missing: {e}")
+
+        fetcher = YouTubeFetcher.__new__(YouTubeFetcher)
+        video = VideoInfo.model_construct(
+            title="t",
+            description="d",
+            author={"name": "a"},
+            article=None,
+        )
+        fetcher.get_video_info = AsyncMock(return_value=video)
+        fetcher._extract_video_id = MagicMock(return_value="toRqAY3xp4A")
+        fetcher._get_transcript = AsyncMock(return_value=None)
+        fetcher._select_fallback_podcast_url = AsyncMock(return_value=(None, None, ""))
+
+        with patch(
+            "app.services.content_fetcher.youtube.YouTubeAudioAsrProvider"
+        ) as provider_cls:
+            provider_cls.return_value.transcribe = AsyncMock(return_value=None)
+            result = await fetcher.fetch("https://www.youtube.com/watch?v=toRqAY3xp4A")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_youtube_no_caption.py
+++ b/backend/tests/test_youtube_no_caption.py
@@ -68,6 +68,7 @@ class YoutubeAudioDownloadCommandTest(unittest.TestCase):
         provider.yt_dlp = "/usr/bin/yt-dlp"
         provider.node = "/usr/bin/node"
         provider.ffmpeg = "/usr/bin/ffmpeg"
+        provider._webshare_proxy_urls = MagicMock(return_value=[])
 
         with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
             run.return_value = MagicMock(returncode=0, stderr="", stdout="")
@@ -78,33 +79,32 @@ class YoutubeAudioDownloadCommandTest(unittest.TestCase):
             self.assertEqual(cmd[0], "/usr/bin/yt-dlp")
             self.assertIn("--js-runtimes", cmd)
             self.assertIn("node:/usr/bin/node", cmd)
+            self.assertIn("--impersonate", cmd)
+            self.assertIn("chrome", cmd)
+            self.assertIn("youtube:player_client=tv_embedded", cmd)
             self.assertIn("140/bestaudio[ext=m4a]/bestaudio", cmd)
             self.assertNotIn("--proxy", cmd)
 
-    def test_download_uses_proxy_when_configured(self):
+    def test_download_uses_webshare_proxy(self):
         from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
 
         provider = YouTubeAudioAsrProvider()
         provider.yt_dlp = "/usr/bin/yt-dlp"
         provider.node = "/usr/bin/node"
         provider.ffmpeg = "/usr/bin/ffmpeg"
+        provider._webshare_proxy_urls = MagicMock(return_value=["http://proxy.example:8080"])
 
-        with patch.dict(
-            os.environ,
-            {"USE_PROXY": "true", "PROXY_URL": "http://proxy.example:8080"},
-            clear=False,
-        ):
-            with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
-                run.return_value = MagicMock(returncode=0, stderr="", stdout="")
-                with patch("app.services.transcript.youtube_audio.Path.glob", return_value=[]):
-                    with self.assertRaises(RuntimeError):
-                        provider._download_audio(
-                            "https://www.youtube.com/watch?v=toRqAY3xp4A", "/tmp/x"
-                        )
-            cmd = run.call_args[0][0]
-            self.assertIn("--proxy", cmd)
-            self.assertIn("http://proxy.example:8080", cmd)
-            self.assertIn("--no-check-certificates", cmd)
+        with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+            with patch("app.services.transcript.youtube_audio.Path.glob", return_value=[]):
+                with self.assertRaises(RuntimeError):
+                    provider._download_audio(
+                        "https://www.youtube.com/watch?v=toRqAY3xp4A", "/tmp/x"
+                    )
+        cmd = run.call_args[0][0]
+        self.assertIn("--proxy", cmd)
+        self.assertIn("http://proxy.example:8080", cmd)
+        self.assertNotIn("--no-check-certificates", cmd)
 
 
 class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):

--- a/backend/tests/test_youtube_no_caption.py
+++ b/backend/tests/test_youtube_no_caption.py
@@ -82,6 +82,35 @@ class YoutubeAudioDownloadCommandTest(unittest.TestCase):
 
 
 class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_uses_captions_and_skips_audio_asr(self):
+        try:
+            from app.services.content_fetcher.youtube import YouTubeFetcher
+            from app.services.content_fetcher.base import VideoInfo
+        except ImportError as e:
+            self.skipTest(f"youtube fetcher deps missing: {e}")
+
+        fetcher = YouTubeFetcher.__new__(YouTubeFetcher)
+        video = VideoInfo.model_construct(
+            title="t",
+            description="d",
+            author={"name": "a"},
+            article=None,
+        )
+        fetcher.get_video_info = AsyncMock(return_value=video)
+        fetcher._extract_video_id = MagicMock(return_value="IFvLorAL5-8")
+        fetcher._get_transcript = AsyncMock(return_value="[00:00:00] caption text")
+        fetcher._select_fallback_podcast_url = AsyncMock()
+
+        with patch(
+            "app.services.content_fetcher.youtube.YouTubeAudioAsrProvider"
+        ) as provider_cls:
+            result = await fetcher.fetch("https://www.youtube.com/watch?v=IFvLorAL5-8")
+
+        provider_cls.assert_not_called()
+        fetcher._select_fallback_podcast_url.assert_not_called()
+        self.assertIsNotNone(result)
+        self.assertIn("转录内容: [00:00:00] caption text", result)
+
     async def test_fetch_returns_none_when_all_transcripts_fail(self):
         try:
             from app.services.content_fetcher.youtube import YouTubeFetcher

--- a/src/types/section.ts
+++ b/src/types/section.ts
@@ -56,7 +56,8 @@ export const ALL_SECTION_TYPES: SectionType[] = [
 // 默认选中的小节 - 移除工具相关的小节
 export const DEFAULT_SELECTED_SECTIONS: SectionType[] = [
   '总结',
-  '分段详述'
+  '分段详述',
+  '原文字幕'
 ];
 
 // 工具按钮对应的小节类型


### PR DESCRIPTION
## Summary
- 无字幕 YouTube 不再用标题/描述脑补总结；字幕和小宇宙兜底都失败后，下载 m4a 上传到现有 private-uploads，再交给腾讯云转写。
- Lightsail 无法直连 YouTube CDN，生产下载走 Webshare HTTP 代理 + Chrome 伪装 + `tv_embedded` 客户端。
- 有字幕 YouTube 仍走原字幕链路；小宇宙逻辑不变。前端默认勾选「原文字幕」。

## Test plan
- [x] 生产：有字幕 YouTube 走 Supadata，不触发音频 ASR
- [x] 生产：小宇宙仍能拿音频并腾讯转写成功
- [x] 生产：无字幕 YouTube（toRqAY3xp4A）下载 m4a + 腾讯 ASR，内容含「转录内容:」
- [x] 单元测试 `tests.test_youtube_no_caption`


Made with [Cursor](https://cursor.com)