### PR TITLE
fix: 详情页默认不再展示原文字幕

### DIFF
--- a/src/types/section.ts
+++ b/src/types/section.ts
@@ -56,8 +56,7 @@ export const ALL_SECTION_TYPES: SectionType[] = [
 // 默认选中的小节 - 移除工具相关的小节
 export const DEFAULT_SELECTED_SECTIONS: SectionType[] = [
   '总结',
-  '分段详述',
-  '原文字幕'
+  '分段详述'
 ];
 
 // 工具按钮对应的小节类型


### PR DESCRIPTION
## Summary
- 详情页默认小节改回「总结 + 分段详述」，不再默认展开原文字幕。
- Trending / Segmented Outline / Key Takeaways / 人物介绍 等仍在总结正文里，不受影响。字幕仍会生成入库。

## Test plan
- [ ] 打开 https://www.keep-up.cn/article/2800 ，确认没有 Original Subtitles 整段
- [ ] 确认 Summary、人物介绍、Key Takeaways、Trending、Segmented Outline 仍在


Made with [Cursor](https://cursor.com)