### PR TITLE
feat: 无字幕 YouTube 改走 Supadata Whisper

### DIFF
--- a/backend/app/services/content_fetcher/youtube.py
+++ b/backend/app/services/content_fetcher/youtube.py
@@ -19,7 +19,7 @@ from app.models.request import FetchRequest
 from app.models.author import AuthorInfo
 from app.models.article import ArticleCreate
 from app.services.transcript.fallback_provider import TranscriptFallbackProvider
-from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
+from app.services.transcript.supadata import SupadataTranscriptClient
 from app.services.transcript.text_utils import build_youtube_content
 import unicodedata
 import os
@@ -189,15 +189,14 @@ class YouTubeFetcher(ContentFetcher):
                     # 兜底错误不影响主流程
                     logger.exception("[YT Fallback] Unexpected error during fallback pipeline")
 
-            # 字幕与小宇宙都失败时，下载音频走腾讯 ASR（与私密音频同一套公网 URL）
+            # 字幕与小宇宙都失败时，让 Supadata 用 Whisper 生成转写（不在 Lightsail 上下 YouTube 音频）
             if not transcript:
                 try:
-                    user_id = (request.user_id if request else None) or "youtube-asr"
-                    logger.info("[YT Audio ASR] Captions empty. Download audio and transcribe...")
-                    provider = YouTubeAudioAsrProvider()
-                    transcript = await provider.transcribe(url, user_id)
+                    logger.info("[YT Supadata] Captions empty. Request mode=auto (native then Whisper)...")
+                    provider = SupadataTranscriptClient()
+                    transcript = await asyncio.to_thread(provider.transcribe, url, "auto")
                 except Exception:
-                    logger.exception("[YT Audio ASR] Unexpected error during audio ASR pipeline")
+                    logger.exception("[YT Supadata] Unexpected error during Whisper fallback")
                     transcript = None
 
             content = build_youtube_content(
@@ -207,7 +206,7 @@ class YouTubeFetcher(ContentFetcher):
                 transcript,
             )
             if not content:
-                logger.error("YouTube transcript unavailable after captions, XiaoYuZhou fallback, and audio ASR")
+                logger.error("YouTube transcript unavailable after captions, XiaoYuZhou fallback, and Supadata Whisper")
                 return None
 
             logger.info(f"成功获取YouTube内容，长度: {len(content)}")

--- a/backend/app/services/transcript/supadata.py
+++ b/backend/app/services/transcript/supadata.py
@@ -1,0 +1,137 @@
+"""Supadata transcript client.
+
+Native captions stay on the existing `/v1/youtube/transcript` path.
+When those are missing, this client calls `/v1/transcript?mode=auto` so
+Supadata can fall back to Whisper on their side — Lightsail never downloads
+YouTube audio.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Optional
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # tests / slim environments
+    def load_dotenv(*_args, **_kwargs):
+        return False
+
+from app.services.transcript.text_utils import ms_to_hhmmss
+
+try:
+    from app.utils.logger import logger
+except Exception:  # pragma: no cover
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+
+class SupadataTranscriptClient:
+    """GET /v1/transcript with job polling for long Whisper jobs."""
+
+    BASE_URL = "https://api.supadata.ai/v1"
+
+    def __init__(self) -> None:
+        load_dotenv()
+        self.api_key = os.getenv("SUPERDATA_KEY") or os.getenv("superdata_KEY")
+        self.poll_interval = int(os.getenv("SUPADATA_POLL_INTERVAL", "2"))
+        self.poll_timeout = int(os.getenv("SUPADATA_POLL_TIMEOUT", "1800"))
+        self.request_timeout = int(os.getenv("SUPADATA_GENERATE_TIMEOUT", "150"))
+
+    def _headers(self) -> dict[str, str]:
+        return {"x-api-key": self.api_key or ""}
+
+    @staticmethod
+    def to_bracketed_transcript(content: Any) -> str:
+        if isinstance(content, str):
+            text = content.strip()
+            return f"[00:00:00] {text}" if text else ""
+        if not isinstance(content, list):
+            return ""
+        lines: list[str] = []
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            text = strip_text(item.get("text"))
+            if not text:
+                continue
+            ts = ms_to_hhmmss(item.get("offset") or 0)
+            lines.append(f"[{ts}] {text}")
+        return "\n".join(lines)
+
+    def transcribe(self, video_url: str, mode: str = "auto") -> Optional[str]:
+        if not self.api_key:
+            logger.warning("[YT Supadata] SUPERDATA_KEY missing; skip Whisper fallback")
+            return None
+        if not video_url:
+            return None
+
+        logger.info(f"[YT Supadata] mode={mode} url={video_url}")
+        response = requests.get(
+            f"{self.BASE_URL}/transcript",
+            headers=self._headers(),
+            params={"url": video_url, "mode": mode, "text": "false"},
+            timeout=self.request_timeout,
+        )
+        if response.status_code == 202:
+            job_id = (response.json() or {}).get("jobId")
+            if not job_id:
+                logger.warning("[YT Supadata] 202 without jobId")
+                return None
+            logger.info(f"[YT Supadata] async job_id={job_id}")
+            return self._poll_job(job_id)
+        if response.status_code != 200:
+            logger.warning(
+                f"[YT Supadata] request failed: {response.status_code} - {response.text[:500]}"
+            )
+            return None
+
+        data = response.json() or {}
+        if data.get("jobId") and not data.get("content"):
+            logger.info(f"[YT Supadata] async job_id={data.get('jobId')}")
+            return self._poll_job(data["jobId"])
+        return self._content_or_none(data.get("content"))
+
+    def _poll_job(self, job_id: str) -> Optional[str]:
+        started = time.time()
+        while True:
+            response = requests.get(
+                f"{self.BASE_URL}/transcript/{job_id}",
+                headers=self._headers(),
+                timeout=30,
+            )
+            if response.status_code != 200:
+                logger.warning(
+                    f"[YT Supadata] poll failed: {response.status_code} - {response.text[:500]}"
+                )
+                return None
+            data = response.json() or {}
+            status = data.get("status")
+            if status == "completed":
+                logger.info("[YT Supadata] job completed")
+                return self._content_or_none(data.get("content"))
+            if status == "failed":
+                logger.warning(f"[YT Supadata] job failed: {data.get('error')}")
+                return None
+            if time.time() - started > self.poll_timeout:
+                logger.warning("[YT Supadata] poll timeout")
+                return None
+            logger.info(f"[YT Supadata] job status={status}")
+            time.sleep(self.poll_interval)
+
+    def _content_or_none(self, content: Any) -> Optional[str]:
+        transcript = self.to_bracketed_transcript(content)
+        if not transcript.strip():
+            logger.warning("[YT Supadata] empty transcript")
+            return None
+        logger.info(f"[YT Supadata] transcript length={len(transcript)}")
+        return transcript
+
+
+def strip_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/backend/app/services/transcript/text_utils.py
+++ b/backend/app/services/transcript/text_utils.py
@@ -7,6 +7,15 @@ from typing import Optional
 INNER_TIMESTAMP_RE = re.compile(r"\[\d+:\d+(?:\.\d+)?,\d+:\d+(?:\.\d+)?\]\s*")
 
 
+def ms_to_hhmmss(ms: float) -> str:
+    """Convert millisecond offsets from Supadata chunks to [HH:MM:SS] prefixes."""
+    seconds = max(0, int(float(ms) / 1000.0))
+    hours = seconds // 3600
+    minutes = (seconds % 3600) // 60
+    secs = seconds % 60
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
 def strip_inner_timestamps(text: Optional[str]) -> str:
     if not text:
         return ""

--- a/backend/tests/test_youtube_no_caption.py
+++ b/backend/tests/test_youtube_no_caption.py
@@ -60,51 +60,87 @@ class BuildYoutubeContentTest(unittest.TestCase):
         self.assertIn("转录内容: [00:00:00] hello", content)
 
 
-class YoutubeAudioDownloadCommandTest(unittest.TestCase):
-    def test_download_invokes_yt_dlp_with_node_runtime(self):
-        from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
+class MsToHhmmssTest(unittest.TestCase):
+    def test_zero(self):
+        from app.services.transcript.text_utils import ms_to_hhmmss
 
-        provider = YouTubeAudioAsrProvider()
-        provider.yt_dlp = "/usr/bin/yt-dlp"
-        provider.node = "/usr/bin/node"
-        provider.ffmpeg = "/usr/bin/ffmpeg"
-        provider._webshare_proxy_urls = MagicMock(return_value=[])
+        self.assertEqual(ms_to_hhmmss(0), "00:00:00")
 
-        with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
-            run.return_value = MagicMock(returncode=0, stderr="", stdout="")
-            with patch("app.services.transcript.youtube_audio.Path.glob", return_value=[]):
-                with self.assertRaises(RuntimeError):
-                    provider._download_audio("https://www.youtube.com/watch?v=toRqAY3xp4A", "/tmp/x")
-            cmd = run.call_args[0][0]
-            self.assertEqual(cmd[0], "/usr/bin/yt-dlp")
-            self.assertIn("--js-runtimes", cmd)
-            self.assertIn("node:/usr/bin/node", cmd)
-            self.assertIn("--impersonate", cmd)
-            self.assertIn("chrome", cmd)
-            self.assertIn("youtube:player_client=tv_embedded", cmd)
-            self.assertIn("140/bestaudio[ext=m4a]/bestaudio", cmd)
-            self.assertNotIn("--proxy", cmd)
+    def test_minutes_and_seconds(self):
+        from app.services.transcript.text_utils import ms_to_hhmmss
 
-    def test_download_uses_webshare_proxy(self):
-        from app.services.transcript.youtube_audio import YouTubeAudioAsrProvider
+        self.assertEqual(ms_to_hhmmss(8150), "00:00:08")
+        self.assertEqual(ms_to_hhmmss(75_000), "00:01:15")
 
-        provider = YouTubeAudioAsrProvider()
-        provider.yt_dlp = "/usr/bin/yt-dlp"
-        provider.node = "/usr/bin/node"
-        provider.ffmpeg = "/usr/bin/ffmpeg"
-        provider._webshare_proxy_urls = MagicMock(return_value=["http://proxy.example:8080"])
 
-        with patch("app.services.transcript.youtube_audio.subprocess.run") as run:
-            run.return_value = MagicMock(returncode=0, stderr="", stdout="")
-            with patch("app.services.transcript.youtube_audio.Path.glob", return_value=[]):
-                with self.assertRaises(RuntimeError):
-                    provider._download_audio(
-                        "https://www.youtube.com/watch?v=toRqAY3xp4A", "/tmp/x"
-                    )
-        cmd = run.call_args[0][0]
-        self.assertIn("--proxy", cmd)
-        self.assertIn("http://proxy.example:8080", cmd)
-        self.assertNotIn("--no-check-certificates", cmd)
+class SupadataTranscriptClientTest(unittest.TestCase):
+    def test_chunks_to_bracketed(self):
+        from app.services.transcript.supadata import SupadataTranscriptClient
+
+        text = SupadataTranscriptClient.to_bracketed_transcript(
+            [
+                {"text": "hello", "offset": 0, "duration": 1000},
+                {"text": "world", "offset": 8150, "duration": 1200},
+            ]
+        )
+        self.assertEqual(text, "[00:00:00] hello\n[00:00:08] world")
+
+    def test_plain_string_content(self):
+        from app.services.transcript.supadata import SupadataTranscriptClient
+
+        text = SupadataTranscriptClient.to_bracketed_transcript("hello world")
+        self.assertEqual(text, "[00:00:00] hello world")
+
+    def test_empty_content(self):
+        from app.services.transcript.supadata import SupadataTranscriptClient
+
+        self.assertEqual(SupadataTranscriptClient.to_bracketed_transcript([]), "")
+        self.assertEqual(SupadataTranscriptClient.to_bracketed_transcript(""), "")
+
+    def test_missing_key_returns_none(self):
+        from app.services.transcript.supadata import SupadataTranscriptClient
+
+        client = SupadataTranscriptClient()
+        client.api_key = None
+        self.assertIsNone(client.transcribe("https://www.youtube.com/watch?v=toRqAY3xp4A"))
+
+    def test_mode_auto_immediate_200(self):
+        from app.services.transcript.supadata import SupadataTranscriptClient
+
+        client = SupadataTranscriptClient()
+        client.api_key = "test-key"
+        payload = {
+            "content": [{"text": "深蹲", "offset": 0, "duration": 1200, "lang": "zh"}],
+            "lang": "zh",
+        }
+        with patch("app.services.transcript.supadata.requests.get") as get:
+            get.return_value = MagicMock(status_code=200, json=lambda: payload, text="")
+            result = client.transcribe("https://www.youtube.com/watch?v=toRqAY3xp4A", "auto")
+        self.assertEqual(result, "[00:00:00] 深蹲")
+        args, kwargs = get.call_args
+        self.assertIn("/transcript", args[0])
+        self.assertEqual(kwargs["params"]["mode"], "auto")
+        self.assertEqual(kwargs["params"]["text"], "false")
+
+    def test_polls_202_job_until_completed(self):
+        from app.services.transcript.supadata import SupadataTranscriptClient
+
+        client = SupadataTranscriptClient()
+        client.api_key = "test-key"
+        client.poll_interval = 0
+        queued = MagicMock(status_code=202, json=lambda: {"jobId": "job-1"}, text="")
+        pending = MagicMock(status_code=200, json=lambda: {"status": "active"}, text="")
+        done = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "status": "completed",
+                "content": [{"text": "hello", "offset": 1000, "duration": 500}],
+            },
+            text="",
+        )
+        with patch("app.services.transcript.supadata.requests.get", side_effect=[queued, pending, done]):
+            result = client.transcribe("https://www.youtube.com/watch?v=xxqFoBHD9UE")
+        self.assertEqual(result, "[00:00:01] hello")
 
 
 class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):
@@ -128,7 +164,7 @@ class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):
         fetcher._select_fallback_podcast_url = AsyncMock()
 
         with patch(
-            "app.services.content_fetcher.youtube.YouTubeAudioAsrProvider"
+            "app.services.content_fetcher.youtube.SupadataTranscriptClient"
         ) as provider_cls:
             result = await fetcher.fetch("https://www.youtube.com/watch?v=IFvLorAL5-8")
 
@@ -157,11 +193,41 @@ class YoutubeFetchFailClosedTest(unittest.IsolatedAsyncioTestCase):
         fetcher._select_fallback_podcast_url = AsyncMock(return_value=(None, None, ""))
 
         with patch(
-            "app.services.content_fetcher.youtube.YouTubeAudioAsrProvider"
+            "app.services.content_fetcher.youtube.SupadataTranscriptClient"
         ) as provider_cls:
-            provider_cls.return_value.transcribe = AsyncMock(return_value=None)
+            provider_cls.return_value.transcribe = MagicMock(return_value=None)
             result = await fetcher.fetch("https://www.youtube.com/watch?v=toRqAY3xp4A")
+        provider_cls.assert_called_once()
         self.assertIsNone(result)
+
+    async def test_fetch_uses_supadata_whisper_when_captions_empty(self):
+        try:
+            from app.services.content_fetcher.youtube import YouTubeFetcher
+            from app.services.content_fetcher.base import VideoInfo
+        except ImportError as e:
+            self.skipTest(f"youtube fetcher deps missing: {e}")
+
+        fetcher = YouTubeFetcher.__new__(YouTubeFetcher)
+        video = VideoInfo.model_construct(
+            title="t",
+            description="d",
+            author={"name": "a"},
+            article=None,
+        )
+        fetcher.get_video_info = AsyncMock(return_value=video)
+        fetcher._extract_video_id = MagicMock(return_value="NESeTg2-9bk")
+        fetcher._get_transcript = AsyncMock(return_value=None)
+        fetcher._select_fallback_podcast_url = AsyncMock(return_value=(None, None, ""))
+
+        with patch(
+            "app.services.content_fetcher.youtube.SupadataTranscriptClient"
+        ) as provider_cls:
+            provider_cls.return_value.transcribe = MagicMock(
+                return_value="[00:00:00] generated speech"
+            )
+            result = await fetcher.fetch("https://www.youtube.com/watch?v=NESeTg2-9bk")
+        self.assertIsNotNone(result)
+        self.assertIn("转录内容: [00:00:00] generated speech", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 没字幕的 YouTube 不再让 Lightsail 用 yt-dlp/Webshare 下音频（生产上 googlevideo 全 403）。
- 原生字幕仍走原来的 Supadata `/v1/youtube/transcript` + youtube-transcript-api + 小宇宙。
- 都失败后改为 `GET /v1/transcript?mode=auto`：有字幕用字幕，没有则由 Supadata Whisper 生成；长视频按文档轮询 `jobId`。
- 转写失败仍然整篇失败，避免再用标题描述脑补总结。

## 云上已验证
- 文档确认 `mode=auto` 会 native → Whisper。
- 无 key 调用真实接口返回 `401 Unauthorized`，说明新 endpoint 可用、这台云机器能访问 `api.supadata.ai`。
- 单元测试覆盖立即 200、202 轮询、空结果、缺 key、有字幕时不走 Whisper。

## 这台云 Agent 做不到的
没有本机 `.env`、没有 Lightsail pem，所以：
- 不能用 `SUPERDATA_KEY` 对那 3 条视频做真实 Whisper 试跑
- 不能 SSH 上生产 `docker compose` 发布
- 不能在生产重提 `43wiqS6xfes` / `xxqFoBHD9UE` / `NESeTg2-9bk`

请在本机 Agent 或 SSH Lightsail 后：`git pull` 该分支 → 重建 `backend-api-1` → 再提交这 3 条链接验收。

## Test plan
- [x] `PYTHONPATH=. python3 -m unittest tests.test_youtube_no_caption -v`（fetch 集成测因云环境缺 pydantic 被 skip）
- [ ] 生产：有字幕 YouTube 仍不走 Whisper
- [ ] 生产：重提失败的 3 条无字幕视频，应出现 `转录内容:` 且 status=processed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1dd9beb1-a9bf-44f9-a500-a3457c217a4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1dd9beb1-a9bf-44f9-a500-a3457c217a4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

